### PR TITLE
Fix resetphotos

### DIFF
--- a/DB/DB.swift
+++ b/DB/DB.swift
@@ -324,7 +324,6 @@ class DB {
             let card = getCard(ID)
             try realm.write{
                 card.flag = flagStatement
-                card.updated = flagStatement
             }
         }catch{
             print("フラグ値上書き失敗")

--- a/DB/DB.swift
+++ b/DB/DB.swift
@@ -116,6 +116,7 @@ class DB {
         for i in 1..<self.cardListSize(){
             self.linkToCardData(self.getDefaultPhoto(i))
             self.linkToCardData(self.getDefaultText(i))
+            self.setFlag(i, flagStatement: false)
         }
     }
     
@@ -323,9 +324,23 @@ class DB {
             let card = getCard(ID)
             try realm.write{
                 card.flag = flagStatement
+                card.updated = flagStatement
             }
         }catch{
             print("フラグ値上書き失敗")
+        }
+    }
+    
+    func setUpdated(ID: Int, flagStatement: Bool){
+        do{
+            let realmPath = self.getRealmPath()
+            let realm = try! Realm(path: realmPath)
+            let card = getCard(ID)
+            try realm.write{
+                card.updated = flagStatement
+            }
+        }catch{
+            print("updated値上書き失敗")
         }
     }
     

--- a/DB/DB.swift
+++ b/DB/DB.swift
@@ -116,7 +116,7 @@ class DB {
         for i in 1..<self.cardListSize(){
             self.linkToCardData(self.getDefaultPhoto(i))
             self.linkToCardData(self.getDefaultText(i))
-            self.setFlag(i, flagStatement: false)
+            self.setUpdated(i, flagStatement: false)
         }
     }
     


### PR DESCRIPTION
・リセットボタンを押して写真をもとに戻す処理を行うと，振り返り画面で撮影写真が存在していることになっていた問題を修正

リセットボタンを押して動作する`func initAll()`内でCardDataのupdated属性をfalseにする関数を呼び出すようにした．
振り返り画面ではCardData内のupdated属性がtrueのものを撮影した写真として判断している．
