### PR TITLE
Fix starbug

### DIFF
--- a/DB/AppDelegate.swift
+++ b/DB/AppDelegate.swift
@@ -28,6 +28,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     
     func application(application: UIApplication, didFinishLaunchingWithOptions launchOptions: [NSObject: AnyObject]?) -> Bool {
         // Override point for customization after application launch.
+        DB().copyDB()
         flaglist = DB().getFlagStatementList()
 
         return true

--- a/DB/AppDelegate.swift
+++ b/DB/AppDelegate.swift
@@ -24,8 +24,12 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     
     var pic_segmented = 0
 
+    var flaglist: [Bool] = []
+    
     func application(application: UIApplication, didFinishLaunchingWithOptions launchOptions: [NSObject: AnyObject]?) -> Bool {
         // Override point for customization after application launch.
+        flaglist = DB().getFlagStatementList()
+
         return true
     }
 

--- a/DB/ViewController.swift
+++ b/DB/ViewController.swift
@@ -12,7 +12,6 @@ import RealmSwift
 class ViewController: UIViewController, UITextFieldDelegate {
     override func viewDidLoad() {
         super.viewDidLoad()
-        DB().copyDB()
         DB().showDBPass()
     }
     

--- a/DB/cardList.swift
+++ b/DB/cardList.swift
@@ -16,7 +16,6 @@ class cardList: UIViewController, UITableViewDelegate, UITableViewDataSource{
     @IBOutlet weak var navigation: UINavigationBar!
     
     var cards:[cardData] = [cardData]()
-    let set = setCardList()
     let appDelegate:AppDelegate = UIApplication.sharedApplication().delegate as! AppDelegate
 
     override func viewDidLoad() {
@@ -79,10 +78,6 @@ class cardList: UIViewController, UITableViewDelegate, UITableViewDataSource{
         cell.setCell(cards[indexPath.row])
         cell.backgroundColor = UIColor.clearColor()
         cell.contentView.backgroundColor = UIColor.clearColor()
-        
-        
-        //DBからフラグの情報を配列で受け取る
-        //配列の要素をもとにif文で分岐
         
         if appDelegate.flaglist[indexPath.row] == true {
             cell.flag.tintColor = UIColor.orangeColor()

--- a/DB/cardList.swift
+++ b/DB/cardList.swift
@@ -17,7 +17,8 @@ class cardList: UIViewController, UITableViewDelegate, UITableViewDataSource{
     
     var cards:[cardData] = [cardData]()
     let set = setCardList()
-    
+    let appDelegate:AppDelegate = UIApplication.sharedApplication().delegate as! AppDelegate
+
     override func viewDidLoad() {
         super.viewDidLoad()
         // Do any additional setup after loading the view, typically from a nib.
@@ -78,6 +79,17 @@ class cardList: UIViewController, UITableViewDelegate, UITableViewDataSource{
         cell.setCell(cards[indexPath.row])
         cell.backgroundColor = UIColor.clearColor()
         cell.contentView.backgroundColor = UIColor.clearColor()
+        
+        
+        //DBからフラグの情報を配列で受け取る
+        //配列の要素をもとにif文で分岐
+        
+        if appDelegate.flaglist[indexPath.row] == true {
+            cell.flag.tintColor = UIColor.orangeColor()
+        }else {
+            cell.flag.tintColor = UIColor.lightGrayColor()
+        }
+        
         return cell
     }
     

--- a/DB/setCardList.swift
+++ b/DB/setCardList.swift
@@ -109,6 +109,9 @@ UINavigationControllerDelegate{
             flag.tintColor = UIColor.lightGrayColor()
             db.setFlag(appDelegate.P_ID!, flagStatement: false)
         }
+        
+        appDelegate.flaglist.removeAll()
+        appDelegate.flaglist = DB().getFlagStatementList()
     }
     
 }


### PR DESCRIPTION
星が消えるバグを修正しました。
データベースの面では問題がなく、tableviewをスクロールした際のセルが再利用されることを考慮したコードの記述漏れでした。

`func tableView(tableView: UITableView, cellForRowAtIndexPath indexPath:NSIndexPath) -> UITableViewCell {`内に外部に宣言してあるflagの配列をもとに星に色を付けるか付けないかの処理を記述しました。

あとは、cardList.swift内に`let set = setCardList()`が記述されていましたが、使用していなかったので削除しました。
