### PR TITLE
現在地が表示されないバグを修正

### DIFF
--- a/DB/Info.plist
+++ b/DB/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>NSLocationAlwaysUsageDescription</key>
+	<string></string>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
 	<key>CFBundleExecutable</key>

--- a/DB/Map.swift
+++ b/DB/Map.swift
@@ -100,6 +100,13 @@ class Map: UIViewController,MKMapViewDelegate,CLLocationManagerDelegate{
         myLocationManager.desiredAccuracy = kCLLocationAccuracyHundredMeters
         myLocationManager.startUpdatingLocation()
         
+        let status = CLLocationManager.authorizationStatus()
+        if(status == CLAuthorizationStatus.NotDetermined) {
+            print("didChangeAuthorizationStatus:\(status)");
+            self.myLocationManager.requestAlwaysAuthorization()
+        }
+
+        
         let db = DB()
         db.showDBPass()
         var flagTrueIDList: [Int]
@@ -174,6 +181,10 @@ class Map: UIViewController,MKMapViewDelegate,CLLocationManagerDelegate{
     
     // アノテーション表示の管理
     func mapView(mapView: MKMapView, viewForAnnotation annotation: MKAnnotation) -> MKAnnotationView? {
+        
+        if annotation is MKUserLocation {
+            return nil
+        }
         
         let myIdentifier = "myPin"
         


### PR DESCRIPTION
現在地が表示されないバグを修正しました。実機で現在地が表示されることは確認済みです。

**変更箇所**
- Info.plist内にNSLocationAlwaysUsageDescriptionタグを追記
- Map.swiftの`func mapView(mapView: MKMapView, viewForAnnotation annotation: MKAnnotation) -> MKAnnotationView?`内に  
  `if annotation is MKUserLocation {`  
  `return nil`  
  `}`
  を追記。

確認お願いします。
